### PR TITLE
Impact of the WildFly catalog

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,11 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
           cache: 'maven'
 
       - name: Restore cached Maven packages

--- a/galleon-content/src/main/resources/layers/standalone/myfaces/layer-spec.xml
+++ b/galleon-content/src/main/resources/layers/standalone/myfaces/layer-spec.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" ?>
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="myfaces">
     <props>
+        <prop name="org.wildfly.category" value="Jakarta EE"/>
+        <prop name="org.wildfly.description" value="Support for Jakarta Faces, MyFaces implementation."/>
         <prop name="org.wildfly.rule.add-on" value="jsf,myfaces" />
         <prop name="org.wildfly.rule.add-on-depends-on" value="only:jsf" />
         <prop name="org.wildfly.rule.add-on-description" value="Support for MyFaces." />

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <version.org.jboss.jboss-dmr>1.6.1.Final</version.org.jboss.jboss-dmr>
         <version.org.wildfly>30.0.0.Final</version.org.wildfly>
         <version.org.wildfly.core>22.0.1.Final</version.org.wildfly.core>
-        <version.org.wildfly.galleon-plugins>7.3.1.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>8.0.0.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.jar.plugin>12.0.0.Beta1</version.org.wildfly.jar.plugin>
         <version.org.wildfly.plugin>5.1.0.Alpha1</version.org.wildfly.plugin>
 


### PR DESCRIPTION
@jasondlee  this change is required for the future WildFly catalog (you can see a POC of it there https://jfdenise.github.io/wildfly-catalog/38.0.0.Beta1-SNAPSHOT/index.html) that document all our feature-packs.
You will find in the section WildFly feature-pack a section "MyFaces 4 Support for WildFly - Feature Pack".

Then the myfaces layer is put in the category "Jakarta EE". You can check if that is fine for you.

We plan to have the catalog in place for WildFLy 39, but the sooner we have integrated such changes the better.

The bump to galleon-plugins 8.0.0.Final implies a minimum JDK version of JDK17. I changed the CI.

A new artifact (classifier doc) will be deployed when you release the feature-pack. This artifact contains some documentation that the catalog requires.

Let me know if that is fine with you.