### PR TITLE
[Issue_18] Add missing java.sql dep to jakarta.faces.impl.myfaces module

### DIFF
--- a/galleon-content/src/main/resources/modules/jakarta/faces/impl/myfaces/module.xml
+++ b/galleon-content/src/main/resources/modules/jakarta/faces/impl/myfaces/module.xml
@@ -30,6 +30,7 @@
         <module name="java.desktop"/>
         <module name="java.logging"/>
         <module name="java.naming"/>
+        <module name="java.sql"/>
         <module name="java.xml"/>
 
         <module name="org.jboss.logging"/>


### PR DESCRIPTION
Resolves #18 

It's surprising this first popped up now. This dep is apparently 13 years old:

https://github.com/apache/myfaces/blame/myfaces-core-module-4.0.3/impl/src/main/java/org/apache/myfaces/view/facelets/component/UIRepeat.java